### PR TITLE
Added SessionHelper to plugin

### DIFF
--- a/Test/Case/View/Helper/BoostCakeSessionHelperTest.php
+++ b/Test/Case/View/Helper/BoostCakeSessionHelperTest.php
@@ -1,0 +1,133 @@
+<?php
+App::uses('BoostCakeSessionHelper', 'BoostCake.View/Helper');
+App::uses('Controller', 'Controller');
+App::uses('View', 'View');
+
+class BoostCakeSessionHelperTest extends CakeTestCase {
+
+	public function setUp() {
+		parent::setUp();
+		$controller = null;
+		$this->View = new View($controller);
+		$this->Session = new BoostCakeSessionHelper($this->View);
+		CakeSession::start();
+
+		if (!CakeSession::started()) {
+			CakeSession::start();
+		}
+
+		$_SESSION = array(
+			'test' => 'info',
+			'Message' => array(
+				'flash' => array(
+					'element' => 'default',
+					'params' => array(),
+					'message' => 'This is a calling'
+				),
+				'flash2' => array(
+					'element' => 'alert',
+					'params' => array(),
+					'message' => 'This is a calling'
+				),
+				'flash3' => array(
+					'element' => 'info',
+					'params' => array(),
+					'message' => 'This is a calling'
+				),
+				'flash4' => array(
+					'element' => 'success',
+					'params' => array(),
+					'message' => 'This is a calling'
+				),
+				'flash5' => array(
+					'element' => 'error',
+					'params' => array(),
+					'message' => 'This is a calling'
+				),
+				'notification' => array(
+					'element' => 'session_helper',
+					'params' => array('title' => 'Notice!', 'name' => 'Alert!'),
+					'message' => 'This is a test of the emergency broadcasting system',
+				),
+				'classy' => array(
+					'element' => 'default',
+					'params' => array('class' => 'positive'),
+					'message' => 'Recorded'
+				),
+				'bare' => array(
+					'element' => null,
+					'message' => 'Bare message',
+					'params' => array(),
+				),
+			),
+			'Deeply' => array('nested' => array('key' => 'value')),
+		);
+	}
+
+/**
+ * tearDown method
+ *
+ * @return void
+ */
+	public function tearDown() {
+		$_SESSION = array();
+		unset($this->View, $this->Session);
+		CakePlugin::unload();
+		parent::tearDown();
+	}
+
+	public function testFlash() {
+		$result = $this->Session->flash('flash');
+		$expected = '<div id="flashMessage" class="message">This is a calling</div>';
+		$this->assertEquals($expected, $result);
+		$this->assertFalse($this->Session->check('Message.flash'));
+
+		$result = $this->Session->flash('flash2');
+		$expected = '<div class="alert">
+	<a class="close" data-dismiss="alert" href="#">×</a>
+	This is a calling</div>';
+		$this->assertEquals($expected, $result);
+		$this->assertFalse($this->Session->check('Message.flash2'));
+
+		$result = $this->Session->flash('flash3');
+		$expected = '<div class="alert alert-info">
+	<a class="close" data-dismiss="alert" href="#">×</a>
+	This is a calling</div>';
+		$this->assertEquals($expected, $result);
+		$this->assertFalse($this->Session->check('Message.flash3'));
+
+		$result = $this->Session->flash('flash4');
+		$expected = '<div class="alert alert-success">
+	<a class="close" data-dismiss="alert" href="#">×</a>
+	This is a calling</div>';
+		$this->assertEquals($expected, $result);
+		$this->assertFalse($this->Session->check('Message.flash4'));
+
+		$result = $this->Session->flash('flash5');
+		$expected = '<div class="alert alert-error">
+	<a class="close" data-dismiss="alert" href="#">×</a>
+	This is a calling</div>';
+		$this->assertEquals($expected, $result);
+		$this->assertFalse($this->Session->check('Message.flash5'));
+
+		$expected = '<div id="classyMessage" class="positive">Recorded</div>';
+		$result = $this->Session->flash('classy');
+		$this->assertEquals($expected, $result);
+
+		App::build(array(
+			'View' => array(CAKE . 'Test' . DS . 'test_app' . DS . 'View' . DS)
+		));
+		$result = $this->Session->flash('notification');
+		$result = str_replace("\r\n", "\n", $result);
+		$expected = "<div id=\"notificationLayout\">\n\t<h1>Alert!</h1>\n\t<h3>Notice!</h3>\n\t<p>This is a test of the emergency broadcasting system</p>\n</div>";
+		$this->assertEquals($expected, $result);
+		$this->assertFalse($this->Session->check('Message.notification'));
+
+		$result = $this->Session->flash('bare');
+		$expected = 'Bare message';
+		$this->assertEquals($expected, $result);
+		$this->assertFalse($this->Session->check('Message.bare'));
+		$_SESSION = array();
+	}
+
+}

--- a/View/Elements/error.ctp
+++ b/View/Elements/error.ctp
@@ -3,7 +3,7 @@ if (!isset($close)) {
 	$close = true;
 }
 ?>
-<div class="alert">
+<div class="alert alert-error">
 <?php if ($close): ?>
 	<a class="close" data-dismiss="alert" href="#">×</a>
 <?php endif; ?>

--- a/View/Elements/info.ctp
+++ b/View/Elements/info.ctp
@@ -3,7 +3,7 @@ if (!isset($close)) {
 	$close = true;
 }
 ?>
-<div class="alert">
+<div class="alert alert-info">
 <?php if ($close): ?>
 	<a class="close" data-dismiss="alert" href="#">×</a>
 <?php endif; ?>

--- a/View/Elements/success.ctp
+++ b/View/Elements/success.ctp
@@ -3,7 +3,7 @@ if (!isset($close)) {
 	$close = true;
 }
 ?>
-<div class="alert">
+<div class="alert alert-success">
 <?php if ($close): ?>
 	<a class="close" data-dismiss="alert" href="#">×</a>
 <?php endif; ?>

--- a/View/Helper/BoostCakeSessionHelper.php
+++ b/View/Helper/BoostCakeSessionHelper.php
@@ -1,0 +1,39 @@
+<?php
+App::uses('SessionHelper', 'View/Helper');
+
+class BoostCakeSessionHelper extends SessionHelper {
+	public function flash($key = 'flash', $attrs = array()) {
+		$out = false;
+
+		if (CakeSession::check('Message.' . $key)) {
+			$flash = CakeSession::read('Message.' . $key);
+			$message = $flash['message'];
+			unset($flash['message']);
+
+			if (!empty($attrs)) {
+				$flash = array_merge($flash, $attrs);
+			}
+
+			if ($flash['element'] === 'default') {
+				$class = 'message';
+				if (!empty($flash['params']['class'])) {
+					$class = $flash['params']['class'];
+				}
+				$out = '<div id="' . $key . 'Message" class="' . $class . '">' . $message . '</div>';
+			} elseif (!$flash['element']) {
+				$out = $message;
+			} else {
+				$options = array();
+				if (isset($flash['params']['plugin'])) {
+					$options['plugin'] = $flash['params']['plugin'];
+				}
+				else {$options['plugin'] ='BoostCake';}
+				$tmpVars = $flash['params'];
+				$tmpVars['message'] = $message;
+				$out = $this->_View->element($flash['element'], $tmpVars, $options);
+			}
+			CakeSession::delete('Message.' . $key);
+		}
+		return $out;
+	}
+}

--- a/View/Helper/BoostCakeSessionHelper.php
+++ b/View/Helper/BoostCakeSessionHelper.php
@@ -2,6 +2,18 @@
 App::uses('SessionHelper', 'View/Helper');
 
 class BoostCakeSessionHelper extends SessionHelper {
+
+/**
+ * Overwrite SessionHelper:flash()
+ * If no option plugin set, then use BoostCake plugin.
+ * Only change from original Session helper is the line
+ * else { $options['plugin'] = 'BoostCake'; }
+ *
+ * @param string $key The [Message.]key you are rendering in the view.
+ * @param array $attrs Additional attributes to use for the creation of this flash message.
+ *    Supports the 'params', and 'element' keys that are used in the helper.
+ * @return string
+ */
 	public function flash($key = 'flash', $attrs = array()) {
 		$out = false;
 
@@ -27,7 +39,9 @@ class BoostCakeSessionHelper extends SessionHelper {
 				if (isset($flash['params']['plugin'])) {
 					$options['plugin'] = $flash['params']['plugin'];
 				}
-				else {$options['plugin'] ='BoostCake';}
+				else {
+					$options['plugin'] = 'BoostCake';
+				}
 				$tmpVars = $flash['params'];
 				$tmpVars['message'] = $message;
 				$out = $this->_View->element($flash['element'], $tmpVars, $options);


### PR DESCRIPTION
Add 'Session' => array('className'=>'BoostCake.BoostCakeSession'), to public $helpers in Appcontroller.
Usage:
$this->Session->setFlash('Message', 'alert');
OR
$this->Session->setFlash('Message', 'info');
OR
$this->Session->setFlash('Message', 'error');
OR
$this->Session->setFlash('Message', 'success');

info alert is the same as default so you can use $this->Session->setFlash('Message'); for default or info elements
