### PR TITLE
fixed jquery url in bootstrap3.ctp.

### DIFF
--- a/View/Layouts/bootstrap3.ctp
+++ b/View/Layouts/bootstrap3.ctp
@@ -73,7 +73,7 @@
 	<!-- Le javascript
 	================================================== -->
 	<!-- Placed at the end of the document so the pages load faster -->
-	<script src="//ajax.googleapis.com/ajax/libs/jquery/1.9/jquery.min.js"></script>
+	<script src="//ajax.googleapis.com/ajax/libs/jquery/1.10.2/jquery.min.js"></script>
 	<script src="//netdna.bootstrapcdn.com/bootstrap/3.0.0/js/bootstrap.min.js"></script>
 	<script src="//google-code-prettify.googlecode.com/svn/loader/run_prettify.js"></script>
 	<?php echo $this->fetch('script'); ?>


### PR DESCRIPTION
http://ajax.googleapis.com/ajax/libs/jquery/1.9/jquery.min.js is 404 Not Found.
see https://developers.google.com/speed/libraries/devguide?hl=ja#jquery
