### PR TITLE
Escape "$" in labels, so preg_replace() doesn't remove it

### DIFF
--- a/View/Helper/BoostCakeFormHelper.php
+++ b/View/Helper/BoostCakeFormHelper.php
@@ -115,6 +115,7 @@ class BoostCakeFormHelper extends FormHelper {
 			}
 			$regex = '/(<label.*?>)(.*?<\/label>)/';
 			if (preg_match($regex, $html, $label)) {
+				$label = str_replace('$', '\$', $label);
 				$html = preg_replace($regex, '', $html);
 				$html = preg_replace(
 					'/(<input type="checkbox".*?>)/',


### PR DESCRIPTION
I noticed that the "$" would get dropped from my labels, because of the preg_replace() action that was being called.  Escaping the character seems to solve the issue.
