### PR TITLE
Automatically apply active class to Paginator::link()

### DIFF
--- a/Config/bootstrap.php
+++ b/Config/bootstrap.php
@@ -1,0 +1,52 @@
+<?php
+/**
+ * Bootstrap version
+ */
+Configure::write('BoostCake.bootstrap_version', '3');
+
+/**
+ * Default inputDefaults by version and form type
+ * Simply supply a form class and the following inputDefaults will be default
+ * These defaults will be overridden by any passed inputDefaults using Hash::merge()
+ */
+Configure::write('BoostCake.inputDefaults', array(
+	'2' => array(
+		'default' => array(
+			'div' => false,
+			'wrapInput' => false
+		),
+		'form-inline' => array(
+			'div' => false,
+			'label' => false,
+			'wrapInput' => false
+		),
+		'form-horizontal' => array(
+			'div' => 'form-group',
+			'label' => array(
+				'class' => 'control-label'
+			),
+			'wrapInput' => 'controls'
+		)
+	),
+	'3' => array(
+		'default' => array(
+			'div' => 'form-group',
+			'wrapInput' => false,
+			'class' => 'form-control'
+		),
+		'form-inline' => array(
+			'div' => 'form-group',
+			'label' => false,
+			'wrapInput' => false,
+			'class' => 'form-control'
+		),
+		'form-horizontal' => array(
+			'div' => 'form-group',
+			'label' => array(
+				'class' => 'col col-md-3 control-label'
+			),
+			'wrapInput' => 'col col-md-9',
+			'class' => 'form-control'
+		)
+	)
+));

--- a/View/Helper/BoostCakeFormHelper.php
+++ b/View/Helper/BoostCakeFormHelper.php
@@ -17,6 +17,58 @@ class BoostCakeFormHelper extends FormHelper {
 	protected $_fieldName = null;
 
 /**
+ * Overwrite FormHelper::create()
+ *
+ * Added: Automatically specifies inputDefaults depending on form class
+ *
+ * Returns an HTML FORM element.
+ *
+ * ### Options:
+ *
+ * - `type` Form method defaults to POST
+ * - `action`  The controller action the form submits to, (optional).
+ * - `url`  The URL the form submits to. Can be a string or a URL array. If you use 'url'
+ *    you should leave 'action' undefined.
+ * - `default`  Allows for the creation of Ajax forms. Set this to false to prevent the default event handler.
+ *   Will create an onsubmit attribute if it doesn't not exist. If it does, default action suppression
+ *   will be appended.
+ * - `onsubmit` Used in conjunction with 'default' to create ajax forms.
+ * - `inputDefaults` set the default $options for FormHelper::input(). Any options that would
+ *   be set when using FormHelper::input() can be set here. Options set with `inputDefaults`
+ *   can be overridden when calling input()
+ * - `encoding` Set the accept-charset encoding for the form. Defaults to `Configure::read('App.encoding')`
+ *
+ * @param mixed $model The model name for which the form is being defined. Should
+ *   include the plugin name for plugin models. e.g. `ContactManager.Contact`.
+ *   If an array is passed and $options argument is empty, the array will be used as options.
+ *   If `false` no model is used.
+ * @param array $options An array of html attributes and options.
+ * @return string An formatted opening FORM tag.
+ * @link http://book.cakephp.org/2.0/en/core-libraries/helpers/form.html#options-for-create
+ */
+	public function create($model = null, $options = array()) {
+		if ($bootstrapVersion = Configure::read('BoostCake.bootstrap_version')) {
+			if (!isset($options['class'])) {
+				$class = 'default';
+			} else {
+				$class = $options['class'];
+			}
+			if ($inputDefaults = Configure::read("BoostCake.inputDefaults.$bootstrapVersion.$class")) {
+				$options = Hash::merge(
+					array(
+						'inputDefaults' => $inputDefaults
+					),
+					$options
+				);
+			}
+		}debug(Configure::read("BoostCake.inputDefaults.$bootstrapVersion.$class"));
+
+		$html = parent::create($model, $options);
+		
+		return $html;
+	}
+	
+/**
  * Overwrite FormHelper::input()
  * Generates a form input element complete with label and wrapper div
  *

--- a/View/Helper/BoostCakeFormHelper.php
+++ b/View/Helper/BoostCakeFormHelper.php
@@ -15,7 +15,7 @@ class BoostCakeFormHelper extends FormHelper {
 	protected $_inputType = null;
 
 	protected $_fieldName = null;
-
+	
 /**
  * Overwrite FormHelper::create()
  *
@@ -61,13 +61,13 @@ class BoostCakeFormHelper extends FormHelper {
 					$options
 				);
 			}
-		}debug(Configure::read("BoostCake.inputDefaults.$bootstrapVersion.$class"));
+		}
 
 		$html = parent::create($model, $options);
 		
 		return $html;
 	}
-	
+
 /**
  * Overwrite FormHelper::input()
  * Generates a form input element complete with label and wrapper div

--- a/View/Helper/BoostCakePaginatorHelper.php
+++ b/View/Helper/BoostCakePaginatorHelper.php
@@ -191,4 +191,46 @@ class BoostCakePaginatorHelper extends PaginatorHelper {
 		);
 	}
 
+/**
+ * Taken from Cake PaginatorHelper, extended to apply active class automatically
+ * 
+ * Generates a plain or Ajax link with pagination parameters
+ *
+ * ### Options
+ *
+ * - `update` The Id of the DOM element you wish to update. Creates Ajax enabled links
+ *    with the AjaxHelper.
+ * - `escape` Whether you want the contents html entity encoded, defaults to true
+ * - `model` The model to use, defaults to PaginatorHelper::defaultModel()
+ *
+ * @param string $title Title for the link.
+ * @param string|array $url Url for the action. See Router::url()
+ * @param array $options Options for the link. See #options for list of keys.
+ * @return string A link with pagination parameters.
+ * @link http://book.cakephp.org/2.0/en/core-libraries/helpers/paginator.html#PaginatorHelper::link
+ */
+	public function link($title, $url = array(), $options = array()) {
+		$named = $this->params['named'];
+		unset($named['sort'], $named['direction'], $named['page']);
+		
+		$match = false;
+		if (count($url) == 1) {
+			$namedParam = key($url);
+			if (($url[$namedParam] === null && !isset($named[$namedParam])) || (isset($named[$namedParam]) && $named[$namedParam] == $url[$namedParam])) {
+				$match = true;
+			}
+		}
+		
+		if (count($url)) {
+			if ($named == $url || $match) {
+				if (isset($options['class']) && !empty($options['class'])) {
+					$options['class'] .= ' active btn-success';
+				} else {
+					$options['class'] = 'active btn-success';
+				}
+			}
+		}
+		
+		return parent::link($title, $url, $options);
+	}
 }


### PR DESCRIPTION
I added the link() method to the Paginator Helper. This is a way to automatically have the active class applied to links or buttons which match the current params.

Let me know if there's a better way. I wasn't sure how best to allow a custom class.
