### PR TITLE
Suggested repo is now twbs/bootstrap.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,6 +24,6 @@
         "composer/installers": "*"
     },
     "suggest": {
-        "twitter/bootstrap": "Bootstrap for Twitter"
+        "twbs/bootstrap": "Bootstrap framework"
     }
 }


### PR DESCRIPTION
The framework is also now simply Bootstrap instead of Twitter Bootstrap.

Thanks for the nice plugin.
