### PR TITLE
mark default radio button selected with bootstrap active class

### DIFF
--- a/View/Helper/BoostCakeHtmlHelper.php
+++ b/View/Helper/BoostCakeHtmlHelper.php
@@ -25,6 +25,12 @@ class BoostCakeHtmlHelper extends HtmlHelper {
 		if ($tag === 'radio') {
 			$regex = '/(<label)(.*?>)/';
 			if (preg_match($regex, $html, $match)) {
+				
+				if((strpos($class, 'btn') !== false) && ($args[3]['checked'] == 'checked'))
+				{
+					$class .= ' active';
+				}
+				
 				$html = $match[1] . ' class="' . $class . '"' . $match[2] . preg_replace($regex, ' ', $html);
 			}
 		}


### PR DESCRIPTION
sample:

``` php
echo $this->Form->input('start_minutes', array(
    'type' => 'radio',
    'class' => 'btn btn-default',
    'div' => false,
    'legend' => false,
    'hiddenField' => false,
    'default' => '0',
    'options' => array('0' => __('now'), '15' => __('in 15 min.'), '30' => __('in 30 min.'))));
```
