### PR TITLE
Update next/prev links to respect disable title and escape options

### DIFF
--- a/Controller/BoostCakeController.php
+++ b/Controller/BoostCakeController.php
@@ -14,8 +14,10 @@ class BoostCakeController extends AppController {
 	);
 
 /**
- * beforeFilter
+ * Before filter
+ *
  * @throws MethodNotAllowedException
+ * @return void
  */
 	public function beforeFilter() {
 		if (Configure::read('debug') < 1) {
@@ -24,9 +26,19 @@ class BoostCakeController extends AppController {
 		parent::beforeFilter();
 	}
 
+/**
+ * Action for plugin documentation home page
+ *
+ * @return void
+ */
 	public function index() {
 	}
 
+/**
+ * Action for Bootstrap 2 example page
+ *
+ * @return void
+ */
 	public function bootstrap2() {
 		$this->Session->setFlash(__('Alert notice message testing...'), 'alert', array(
 			'plugin' => 'BoostCake',
@@ -41,6 +53,11 @@ class BoostCakeController extends AppController {
 		), 'error');
 	}
 
+/**
+ * Action for Bootstrap 3 example page
+ *
+ * @return void
+ */
 	public function bootstrap3() {
 		$this->Session->setFlash(__('Alert success message testing...'), 'alert', array(
 			'plugin' => 'BoostCake',

--- a/Test/Case/AllBoostCakeTest.php
+++ b/Test/Case/AllBoostCakeTest.php
@@ -1,6 +1,11 @@
 <?php
 class AllBoostCakeTest extends CakeTestSuite {
 
+/**
+ * Adds all tests to the AllBoostCakeTest case
+ *
+ * @return CakeTestSuite
+ */
 	public static function suite() {
 		$suite = new CakeTestSuite('All tests');
 		$path = dirname(__FILE__);

--- a/Test/Case/View/Helper/BoostCakeFormHelperTest.php
+++ b/Test/Case/View/Helper/BoostCakeFormHelperTest.php
@@ -32,6 +32,11 @@ class Contact extends CakeTestModel {
 
 class BoostCakeFormHelperTest extends CakeTestCase {
 
+/**
+ * setUp
+ *
+ * @return void
+ */
 	public function setUp() {
 		parent::setUp();
 		$this->View = new View();
@@ -40,11 +45,21 @@ class BoostCakeFormHelperTest extends CakeTestCase {
 		ClassRegistry::addObject('Contact', new Contact());
 	}
 
+/**
+ * tearDown
+ *
+ * @return void
+ */
 	public function tearDown() {
 		unset($this->View);
 		unset($this->Form);
 	}
 
+/**
+ * testInput
+ *
+ * @return void
+ */
 	public function testInput() {
 		$result = $this->Form->input('name');
 		$this->assertTags($result, array(
@@ -108,6 +123,11 @@ class BoostCakeFormHelperTest extends CakeTestCase {
 		));
 	}
 
+/**
+ * testBeforeInputAfterInput
+ *
+ * @return void
+ */
 	public function testBeforeInputAfterInput() {
 		$result = $this->Form->input('name', array(
 			'beforeInput' => 'Before Input',
@@ -127,6 +147,11 @@ class BoostCakeFormHelperTest extends CakeTestCase {
 		));
 	}
 
+/**
+ * testCheckbox
+ *
+ * @return void
+ */
 	public function testCheckbox() {
 		$result = $this->Form->input('name', array('type' => 'checkbox'));
 		$this->assertTags($result, array(
@@ -179,6 +204,11 @@ class BoostCakeFormHelperTest extends CakeTestCase {
 		));
 	}
 
+/**
+ * testCheckboxLabelEscape
+ *
+ * @return void
+ */
 	public function testCheckboxLabelEscape() {
 		$result = $this->Form->input('name', array(
 			'type' => 'checkbox',
@@ -199,6 +229,11 @@ class BoostCakeFormHelperTest extends CakeTestCase {
 		));
 	}
 
+/**
+ * testSelectMultipleCheckbox
+ *
+ * @return void
+ */
 	public function testSelectMultipleCheckbox() {
 		$result = $this->Form->select('name',
 			array(
@@ -290,6 +325,11 @@ class BoostCakeFormHelperTest extends CakeTestCase {
 		));
 	}
 
+/**
+ * testRadio
+ *
+ * @return void
+ */
 	public function testRadio() {
 		$result = $this->Form->input('name', array(
 			'type' => 'radio',
@@ -320,6 +360,11 @@ class BoostCakeFormHelperTest extends CakeTestCase {
 		));
 	}
 
+/**
+ * testErrorMessage
+ *
+ * @return void
+ */
 	public function testErrorMessage() {
 		$Contact = ClassRegistry::getObject('Contact');
 		$Contact->validationErrors['password'] = array('Please provide a password');
@@ -402,6 +447,11 @@ class BoostCakeFormHelperTest extends CakeTestCase {
 		));
 	}
 
+/**
+ * testPostLink
+ *
+ * @return void
+ */
 	public function testPostLink() {
 		$result = $this->Form->postLink('Delete', '/posts/delete/1', array(
 			'block' => 'form'

--- a/Test/Case/View/Helper/BoostCakeHtmlHelperTest.php
+++ b/Test/Case/View/Helper/BoostCakeHtmlHelperTest.php
@@ -4,16 +4,31 @@ App::uses('View', 'View');
 
 class BoostCakeHtmlHelperTest extends CakeTestCase {
 
+/**
+ * setUp
+ *
+ * @return void
+ */
 	public function setUp() {
 		parent::setUp();
 		$View = new View();
 		$this->Html = new BoostCakeHtmlHelper($View);
 	}
 
+/**
+ * tearDown
+ *
+ * @return void
+ */
 	public function tearDown() {
 		unset($this->Html);
 	}
 
+/**
+ * testUseTag
+ *
+ * @return void
+ */
 	public function testUseTag() {
 		$result = $this->Html->useTag(
 			'radio', 'one', 'two', array('three' => 'four'), '<label for="one">label</label>'
@@ -36,6 +51,11 @@ class BoostCakeHtmlHelperTest extends CakeTestCase {
 		));
 	}
 
+/**
+ * testImage
+ *
+ * @return void
+ */
 	public function testImage() {
 		$result = $this->Html->image('', array('data-src' => 'holder.js/24x24'));
 		$this->assertTags($result, array(

--- a/View/Helper/BoostCakeFormHelper.php
+++ b/View/Helper/BoostCakeFormHelper.php
@@ -18,7 +18,8 @@ class BoostCakeFormHelper extends FormHelper {
 
 /**
  * Overwrite FormHelper::input()
- * Generates a form input element complete with label and wrapper div
+ *
+ * - Generates a form input element complete with label and wrapper div
  *
  * ### Options
  *
@@ -139,10 +140,11 @@ class BoostCakeFormHelper extends FormHelper {
 
 /**
  * Overwrite FormHelper::_divOptions()
- * Generate inner and outer div options
- * Generate div options for input
  *
- * @param array $options
+ * - Generate inner and outer div options
+ * - Generate div options for input
+ *
+ * @param array $options Options list.
  * @return array
  */
 	protected function _divOptions($options) {
@@ -165,11 +167,12 @@ class BoostCakeFormHelper extends FormHelper {
 
 /**
  * Overwrite FormHelper::_getInput()
- * Wrap `<div>` input element
- * Generates an input element
  *
- * @param type $args
- * @return type
+ * - Wrap `<div>` input element
+ * - Generates an input element
+ *
+ * @param array $args The options for the input element
+ * @return string The generated input element
  */
 	protected function _getInput($args) {
 		$input = parent::_getInput($args);
@@ -203,13 +206,14 @@ class BoostCakeFormHelper extends FormHelper {
 
 /**
  * Overwrite FormHelper::_selectOptions()
- * If $attributes['style'] is `<input type="checkbox">` then replace `<label>` position
- * Returns an array of formatted OPTION/OPTGROUP elements
  *
- * @param array $elements
- * @param array $parents
- * @param boolean $showParents
- * @param array $attributes
+ * - If $attributes['style'] is `<input type="checkbox">` then replace `<label>` position
+ * - Returns an array of formatted OPTION/OPTGROUP elements
+ *
+ * @param array $elements Elements to format.
+ * @param array $parents Parents for OPTGROUP.
+ * @param bool $showParents Whether to show parents.
+ * @param array $attributes HTML attributes.
  * @return array
  */
 	protected function _selectOptions($elements = array(), $parents = array(), $showParents = null, $attributes = array()) {

--- a/View/Helper/BoostCakePaginatorHelper.php
+++ b/View/Helper/BoostCakePaginatorHelper.php
@@ -91,7 +91,14 @@ class BoostCakePaginatorHelper extends PaginatorHelper {
 		}
 		unset($options['disabled']);
 
-		return parent::prev($title, $options, $this->link($title), array_merge($options, array(
+		if (empty($disabledTitle)) {
+			$disabledTitle = $title;
+		}
+		$disabledTitle = $this->link($disabledTitle, array(), array(
+			'escape' => Hash::get($disabledOptions, 'escape')
+		));
+
+		return parent::prev($title, $options, $disabledTitle, array_merge($options, array(
 			'escape' => false,
 			'class' => $disabled,
 		)));
@@ -118,7 +125,14 @@ class BoostCakePaginatorHelper extends PaginatorHelper {
 		}
 		unset($options['disabled']);
 
-		return parent::next($title, $options, $this->link($title), array_merge($options, array(
+		if (empty($disabledTitle)) {
+			$disabledTitle = $title;
+		}
+		$disabledTitle = $this->link($disabledTitle, array(), array(
+			'escape' => Hash::get($disabledOptions, 'escape')
+		));
+
+		return parent::next($title, $options, $disabledTitle, array_merge($options, array(
 			'escape' => false,
 			'class' => $disabled,
 		)));

--- a/View/Helper/BoostCakePaginatorHelper.php
+++ b/View/Helper/BoostCakePaginatorHelper.php
@@ -3,6 +3,12 @@ App::uses('PaginatorHelper', 'View/Helper');
 
 class BoostCakePaginatorHelper extends PaginatorHelper {
 
+/**
+ * Multi-page pagination component.
+ *
+ * @param array $options Pagination options.
+ * @return string Pagination HTML.
+ */
 	public function pagination($options = array()) {
 		$default = array(
 			'div' => false,
@@ -47,6 +53,12 @@ class BoostCakePaginatorHelper extends PaginatorHelper {
 		return $out;
 	}
 
+/**
+ * Quick previous and next links for simple pagination.
+ *
+ * @param array $options Pager options.
+ * @return string Pager HTML.
+ */
 	public function pager($options = array()) {
 		$default = array(
 			'ul' => 'pager',
@@ -70,6 +82,15 @@ class BoostCakePaginatorHelper extends PaginatorHelper {
 		return $this->Html->tag('ul', implode("\n", $out), compact('class'));
 	}
 
+/**
+ * Generates a "previous" link for a set of paged records
+ *
+ * @param string $title Title for the link. Defaults to '<'.
+ * @param array $options Options for pagination link.
+ * @param string $disabledTitle Title when the link is disabled.
+ * @param array $disabledOptions Options for the disabled pagination link.
+ * @return string A "previous" link or $disabledTitle text if the link is disabled.
+ */
 	public function prev($title = null, $options = array(), $disabledTitle = null, $disabledOptions = array()) {
 		$default = array(
 			'title' => '<',
@@ -104,6 +125,15 @@ class BoostCakePaginatorHelper extends PaginatorHelper {
 		)));
 	}
 
+/**
+ * Generates a "next" link for a set of paged records
+ *
+ * @param string $title Title for the link. Defaults to '>'.
+ * @param array $options Options for pagination link.
+ * @param string $disabledTitle Title when the link is disabled.
+ * @param array $disabledOptions Options for the disabled pagination link.
+ * @return string A "next" link or $disabledTitle text if the link is disabled.
+ */
 	public function next($title = null, $options = array(), $disabledTitle = null, $disabledOptions = array()) {
 		$default = array(
 			'title' => '>',
@@ -138,6 +168,12 @@ class BoostCakePaginatorHelper extends PaginatorHelper {
 		)));
 	}
 
+/**
+ * Returns a set of numbers for the paged result set
+ *
+ * @param array $options Options for the numbers
+ * @return string Numbers HTML
+ */
 	public function numbers($options = array()) {
 		$defaults = array(
 			'tag' => 'li',
@@ -157,6 +193,13 @@ class BoostCakePaginatorHelper extends PaginatorHelper {
 		return preg_replace('@<li class="current">(.*?)</li>@', '<li class="current disabled"><a href="#">\1</a></li>', $return);
 	}
 
+/**
+ * Generates a "first" link for a set of paged records
+ *
+ * @param string $title Title for the link. Defaults to '<<'.
+ * @param array $options An array of options.
+ * @return string A "first" link.
+ */
 	public function first($title = null, $options = array()) {
 		$default = array(
 			'title' => '<<',
@@ -180,6 +223,13 @@ class BoostCakePaginatorHelper extends PaginatorHelper {
 		);
 	}
 
+/**
+ * Generates a "last" link for a set of paged records
+ *
+ * @param string $title Title for the link. Defaults to '>>'.
+ * @param array $options An array of options.
+ * @return string A "last" link.
+ */
 	public function last($title = null, $options = array()) {
 		$default = array(
 			'title' => '>>',


### PR DESCRIPTION
It wasn't possible to disable escaping of HTML link text for disabled next/prev links, while it worked fine for others (active next/prev links and first/last links). Fixes issue shown in screenshot:

![image](https://cloud.githubusercontent.com/assets/24155/4931458/e5b25cb0-6578-11e4-977f-9ee5ace4f542.png)
